### PR TITLE
Sentiment Analysis on web scrapped data with groq API

### DIFF
--- a/market-hedging-sentiment-analysis/Sentiment_Analysis (3).ipynb
+++ b/market-hedging-sentiment-analysis/Sentiment_Analysis (3).ipynb
@@ -1,0 +1,673 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "dBoI7L4hTbM2"
+      },
+      "source": [
+        "Stock Sentiment Analysis of Finviz website using groq API"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 8,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "bVTBDs6rsVKF",
+        "outputId": "3051db64-b902-42b1-c820-b82ffd862a50"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Collecting groq\n",
+            "  Downloading groq-0.9.0-py3-none-any.whl (103 kB)\n",
+            "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/103.5 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m103.5/103.5 kB\u001b[0m \u001b[31m3.0 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hRequirement already satisfied: anyio<5,>=3.5.0 in /usr/local/lib/python3.10/dist-packages (from groq) (3.7.1)\n",
+            "Requirement already satisfied: distro<2,>=1.7.0 in /usr/lib/python3/dist-packages (from groq) (1.7.0)\n",
+            "Collecting httpx<1,>=0.23.0 (from groq)\n",
+            "  Downloading httpx-0.27.0-py3-none-any.whl (75 kB)\n",
+            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m75.6/75.6 kB\u001b[0m \u001b[31m8.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hRequirement already satisfied: pydantic<3,>=1.9.0 in /usr/local/lib/python3.10/dist-packages (from groq) (2.7.4)\n",
+            "Requirement already satisfied: sniffio in /usr/local/lib/python3.10/dist-packages (from groq) (1.3.1)\n",
+            "Requirement already satisfied: typing-extensions<5,>=4.7 in /usr/local/lib/python3.10/dist-packages (from groq) (4.12.2)\n",
+            "Requirement already satisfied: idna>=2.8 in /usr/local/lib/python3.10/dist-packages (from anyio<5,>=3.5.0->groq) (3.7)\n",
+            "Requirement already satisfied: exceptiongroup in /usr/local/lib/python3.10/dist-packages (from anyio<5,>=3.5.0->groq) (1.2.1)\n",
+            "Requirement already satisfied: certifi in /usr/local/lib/python3.10/dist-packages (from httpx<1,>=0.23.0->groq) (2024.6.2)\n",
+            "Collecting httpcore==1.* (from httpx<1,>=0.23.0->groq)\n",
+            "  Downloading httpcore-1.0.5-py3-none-any.whl (77 kB)\n",
+            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m77.9/77.9 kB\u001b[0m \u001b[31m8.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hCollecting h11<0.15,>=0.13 (from httpcore==1.*->httpx<1,>=0.23.0->groq)\n",
+            "  Downloading h11-0.14.0-py3-none-any.whl (58 kB)\n",
+            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m58.3/58.3 kB\u001b[0m \u001b[31m7.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hRequirement already satisfied: annotated-types>=0.4.0 in /usr/local/lib/python3.10/dist-packages (from pydantic<3,>=1.9.0->groq) (0.7.0)\n",
+            "Requirement already satisfied: pydantic-core==2.18.4 in /usr/local/lib/python3.10/dist-packages (from pydantic<3,>=1.9.0->groq) (2.18.4)\n",
+            "Installing collected packages: h11, httpcore, httpx, groq\n",
+            "Successfully installed groq-0.9.0 h11-0.14.0 httpcore-1.0.5 httpx-0.27.0\n"
+          ]
+        }
+      ],
+      "source": [
+        "!pip install groq"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "wQ4Ixo0iYUFq"
+      },
+      "source": [
+        "Extracting the data of amazon, google and meta stocks news from finviz website by web scrapping.\n",
+        "Financial Visualzaion (FinViz) is a website that brings together market data, financial news and analytics tools for investors and traders."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "metadata": {
+        "id": "JV81VmFn9Mp8"
+      },
+      "outputs": [],
+      "source": [
+        "from urllib.request import urlopen, Request # Importing necessary modules for web scraping\n",
+        "from bs4 import BeautifulSoup # Importing BeautifulSoup for HTML parsing\n",
+        "import pandas as pd # Importing pandas for data manipulation"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 4,
+      "metadata": {
+        "id": "7Z21vvwK9Qqf"
+      },
+      "outputs": [],
+      "source": [
+        "# URL of the Finviz website where stock news is located\n",
+        "finviz_url = 'https://finviz.com/quote.ashx?t='\n",
+        "\n",
+        "# List of stock tickers for which we want to fetch news\n",
+        "tickers = ['AMZN', 'GOOG', 'META']"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 9,
+      "metadata": {
+        "id": "W77NKFHzbnOt"
+      },
+      "outputs": [],
+      "source": [
+        "news_tables = {}\n",
+        "# Loop through each ticker, fetch the corresponding news webpage, parse its HTML content\n",
+        "for ticker in tickers:\n",
+        "    url = finviz_url + ticker\n",
+        "\n",
+        "    req = Request(url=url, headers={'user-agent': '_my-app_'})\n",
+        "    response = urlopen(req)\n",
+        "\n",
+        "    html = BeautifulSoup(response, features='html.parser')\n",
+        "    news_table = html.find(id='news-table')\n",
+        "    news_tables[ticker] = news_table\n",
+        "\n",
+        "\n",
+        "parsed_data = []\n",
+        "# Extracting news tables, and storing them in the news_tables dictionary.\n",
+        "for ticker, news_table in news_tables.items():\n",
+        "    for row in news_table.findAll('tr'):\n",
+        "        if row.a and row.td:\n",
+        "            title = row.a.text\n",
+        "            date_data = row.td.text.strip().split(' ')\n",
+        "\n",
+        "            if len(date_data) == 1:\n",
+        "                date = pd.to_datetime('today').strftime('%Y-%m-%d')\n",
+        "                time = date_data[0]\n",
+        "            else:\n",
+        "                date = date_data[0]\n",
+        "                time = date_data[1]\n",
+        "\n",
+        "            parsed_data.append([ticker, date, time, title])\n",
+        "\n",
+        "# Collect the parsed data and store in the dataframe\n",
+        "df = pd.DataFrame(parsed_data, columns=['ticker', 'date', 'time', 'title'])"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 6,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 206
+        },
+        "id": "Jgf7I_dLb4bo",
+        "outputId": "f0cc8143-8611-4a24-ac34-5793d76122f6"
+      },
+      "outputs": [
+        {
+          "data": {
+            "application/vnd.google.colaboratory.intrinsic+json": {
+              "summary": "{\n  \"name\": \"df\",\n  \"rows\": 300,\n  \"fields\": [\n    {\n      \"column\": \"ticker\",\n      \"properties\": {\n        \"dtype\": \"category\",\n        \"num_unique_values\": 3,\n        \"samples\": [\n          \"AMZN\",\n          \"GOOG\",\n          \"META\"\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"date\",\n      \"properties\": {\n        \"dtype\": \"category\",\n        \"num_unique_values\": 12,\n        \"samples\": [\n          \"Jun-12-24\",\n          \"Jun-13-24\",\n          \"Today\"\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"time\",\n      \"properties\": {\n        \"dtype\": \"object\",\n        \"num_unique_values\": 187,\n        \"samples\": [\n          \"02:55PM\",\n          \"11:31AM\",\n          \"06:40AM\"\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"title\",\n      \"properties\": {\n        \"dtype\": \"string\",\n        \"num_unique_values\": 250,\n        \"samples\": [\n          \"Google to invest another $2.3 billion into Ohio data centers\",\n          \"Investors are buying into AI and Musk any way they can: Morning Brief\",\n          \"Amazons Just Walk Out tech to debut at the O2 in London, UK\"\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    }\n  ]\n}",
+              "type": "dataframe",
+              "variable_name": "df"
+            },
+            "text/html": [
+              "\n",
+              "  <div id=\"df-181e3fb1-d7d9-4793-aa29-e2ca96568046\" class=\"colab-df-container\">\n",
+              "    <div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>ticker</th>\n",
+              "      <th>date</th>\n",
+              "      <th>time</th>\n",
+              "      <th>title</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>AMZN</td>\n",
+              "      <td>Today</td>\n",
+              "      <td>08:00AM</td>\n",
+              "      <td>Inside Amazons race to become a $10 trillion g...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>AMZN</td>\n",
+              "      <td>2024-06-21</td>\n",
+              "      <td>07:46AM</td>\n",
+              "      <td>Amazon will stop using those little plastic pi...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2</th>\n",
+              "      <td>AMZN</td>\n",
+              "      <td>2024-06-21</td>\n",
+              "      <td>07:22AM</td>\n",
+              "      <td>3 Penny Stocks to Buy Now: June 2024</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>3</th>\n",
+              "      <td>AMZN</td>\n",
+              "      <td>2024-06-21</td>\n",
+              "      <td>07:00AM</td>\n",
+              "      <td>Microsoft's AI Edge: Why MSFT Stock Is Poised ...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>4</th>\n",
+              "      <td>AMZN</td>\n",
+              "      <td>2024-06-21</td>\n",
+              "      <td>06:52AM</td>\n",
+              "      <td>Hype-nosis: Snap Out of the Trance and See The...</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>\n",
+              "    <div class=\"colab-df-buttons\">\n",
+              "\n",
+              "  <div class=\"colab-df-container\">\n",
+              "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-181e3fb1-d7d9-4793-aa29-e2ca96568046')\"\n",
+              "            title=\"Convert this dataframe to an interactive table.\"\n",
+              "            style=\"display:none;\">\n",
+              "\n",
+              "  <svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\" viewBox=\"0 -960 960 960\">\n",
+              "    <path d=\"M120-120v-720h720v720H120Zm60-500h600v-160H180v160Zm220 220h160v-160H400v160Zm0 220h160v-160H400v160ZM180-400h160v-160H180v160Zm440 0h160v-160H620v160ZM180-180h160v-160H180v160Zm440 0h160v-160H620v160Z\"/>\n",
+              "  </svg>\n",
+              "    </button>\n",
+              "\n",
+              "  <style>\n",
+              "    .colab-df-container {\n",
+              "      display:flex;\n",
+              "      gap: 12px;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-convert {\n",
+              "      background-color: #E8F0FE;\n",
+              "      border: none;\n",
+              "      border-radius: 50%;\n",
+              "      cursor: pointer;\n",
+              "      display: none;\n",
+              "      fill: #1967D2;\n",
+              "      height: 32px;\n",
+              "      padding: 0 0 0 0;\n",
+              "      width: 32px;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-convert:hover {\n",
+              "      background-color: #E2EBFA;\n",
+              "      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
+              "      fill: #174EA6;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-buttons div {\n",
+              "      margin-bottom: 4px;\n",
+              "    }\n",
+              "\n",
+              "    [theme=dark] .colab-df-convert {\n",
+              "      background-color: #3B4455;\n",
+              "      fill: #D2E3FC;\n",
+              "    }\n",
+              "\n",
+              "    [theme=dark] .colab-df-convert:hover {\n",
+              "      background-color: #434B5C;\n",
+              "      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);\n",
+              "      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));\n",
+              "      fill: #FFFFFF;\n",
+              "    }\n",
+              "  </style>\n",
+              "\n",
+              "    <script>\n",
+              "      const buttonEl =\n",
+              "        document.querySelector('#df-181e3fb1-d7d9-4793-aa29-e2ca96568046 button.colab-df-convert');\n",
+              "      buttonEl.style.display =\n",
+              "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
+              "\n",
+              "      async function convertToInteractive(key) {\n",
+              "        const element = document.querySelector('#df-181e3fb1-d7d9-4793-aa29-e2ca96568046');\n",
+              "        const dataTable =\n",
+              "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
+              "                                                    [key], {});\n",
+              "        if (!dataTable) return;\n",
+              "\n",
+              "        const docLinkHtml = 'Like what you see? Visit the ' +\n",
+              "          '<a target=\"_blank\" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'\n",
+              "          + ' to learn more about interactive tables.';\n",
+              "        element.innerHTML = '';\n",
+              "        dataTable['output_type'] = 'display_data';\n",
+              "        await google.colab.output.renderOutput(dataTable, element);\n",
+              "        const docLink = document.createElement('div');\n",
+              "        docLink.innerHTML = docLinkHtml;\n",
+              "        element.appendChild(docLink);\n",
+              "      }\n",
+              "    </script>\n",
+              "  </div>\n",
+              "\n",
+              "\n",
+              "<div id=\"df-86779c9d-550d-49d3-a47a-4cffe9566bd5\">\n",
+              "  <button class=\"colab-df-quickchart\" onclick=\"quickchart('df-86779c9d-550d-49d3-a47a-4cffe9566bd5')\"\n",
+              "            title=\"Suggest charts\"\n",
+              "            style=\"display:none;\">\n",
+              "\n",
+              "<svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\"viewBox=\"0 0 24 24\"\n",
+              "     width=\"24px\">\n",
+              "    <g>\n",
+              "        <path d=\"M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z\"/>\n",
+              "    </g>\n",
+              "</svg>\n",
+              "  </button>\n",
+              "\n",
+              "<style>\n",
+              "  .colab-df-quickchart {\n",
+              "      --bg-color: #E8F0FE;\n",
+              "      --fill-color: #1967D2;\n",
+              "      --hover-bg-color: #E2EBFA;\n",
+              "      --hover-fill-color: #174EA6;\n",
+              "      --disabled-fill-color: #AAA;\n",
+              "      --disabled-bg-color: #DDD;\n",
+              "  }\n",
+              "\n",
+              "  [theme=dark] .colab-df-quickchart {\n",
+              "      --bg-color: #3B4455;\n",
+              "      --fill-color: #D2E3FC;\n",
+              "      --hover-bg-color: #434B5C;\n",
+              "      --hover-fill-color: #FFFFFF;\n",
+              "      --disabled-bg-color: #3B4455;\n",
+              "      --disabled-fill-color: #666;\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-quickchart {\n",
+              "    background-color: var(--bg-color);\n",
+              "    border: none;\n",
+              "    border-radius: 50%;\n",
+              "    cursor: pointer;\n",
+              "    display: none;\n",
+              "    fill: var(--fill-color);\n",
+              "    height: 32px;\n",
+              "    padding: 0;\n",
+              "    width: 32px;\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-quickchart:hover {\n",
+              "    background-color: var(--hover-bg-color);\n",
+              "    box-shadow: 0 1px 2px rgba(60, 64, 67, 0.3), 0 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
+              "    fill: var(--button-hover-fill-color);\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-quickchart-complete:disabled,\n",
+              "  .colab-df-quickchart-complete:disabled:hover {\n",
+              "    background-color: var(--disabled-bg-color);\n",
+              "    fill: var(--disabled-fill-color);\n",
+              "    box-shadow: none;\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-spinner {\n",
+              "    border: 2px solid var(--fill-color);\n",
+              "    border-color: transparent;\n",
+              "    border-bottom-color: var(--fill-color);\n",
+              "    animation:\n",
+              "      spin 1s steps(1) infinite;\n",
+              "  }\n",
+              "\n",
+              "  @keyframes spin {\n",
+              "    0% {\n",
+              "      border-color: transparent;\n",
+              "      border-bottom-color: var(--fill-color);\n",
+              "      border-left-color: var(--fill-color);\n",
+              "    }\n",
+              "    20% {\n",
+              "      border-color: transparent;\n",
+              "      border-left-color: var(--fill-color);\n",
+              "      border-top-color: var(--fill-color);\n",
+              "    }\n",
+              "    30% {\n",
+              "      border-color: transparent;\n",
+              "      border-left-color: var(--fill-color);\n",
+              "      border-top-color: var(--fill-color);\n",
+              "      border-right-color: var(--fill-color);\n",
+              "    }\n",
+              "    40% {\n",
+              "      border-color: transparent;\n",
+              "      border-right-color: var(--fill-color);\n",
+              "      border-top-color: var(--fill-color);\n",
+              "    }\n",
+              "    60% {\n",
+              "      border-color: transparent;\n",
+              "      border-right-color: var(--fill-color);\n",
+              "    }\n",
+              "    80% {\n",
+              "      border-color: transparent;\n",
+              "      border-right-color: var(--fill-color);\n",
+              "      border-bottom-color: var(--fill-color);\n",
+              "    }\n",
+              "    90% {\n",
+              "      border-color: transparent;\n",
+              "      border-bottom-color: var(--fill-color);\n",
+              "    }\n",
+              "  }\n",
+              "</style>\n",
+              "\n",
+              "  <script>\n",
+              "    async function quickchart(key) {\n",
+              "      const quickchartButtonEl =\n",
+              "        document.querySelector('#' + key + ' button');\n",
+              "      quickchartButtonEl.disabled = true;  // To prevent multiple clicks.\n",
+              "      quickchartButtonEl.classList.add('colab-df-spinner');\n",
+              "      try {\n",
+              "        const charts = await google.colab.kernel.invokeFunction(\n",
+              "            'suggestCharts', [key], {});\n",
+              "      } catch (error) {\n",
+              "        console.error('Error during call to suggestCharts:', error);\n",
+              "      }\n",
+              "      quickchartButtonEl.classList.remove('colab-df-spinner');\n",
+              "      quickchartButtonEl.classList.add('colab-df-quickchart-complete');\n",
+              "    }\n",
+              "    (() => {\n",
+              "      let quickchartButtonEl =\n",
+              "        document.querySelector('#df-86779c9d-550d-49d3-a47a-4cffe9566bd5 button');\n",
+              "      quickchartButtonEl.style.display =\n",
+              "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
+              "    })();\n",
+              "  </script>\n",
+              "</div>\n",
+              "\n",
+              "    </div>\n",
+              "  </div>\n"
+            ],
+            "text/plain": [
+              "  ticker        date     time  \\\n",
+              "0   AMZN       Today  08:00AM   \n",
+              "1   AMZN  2024-06-21  07:46AM   \n",
+              "2   AMZN  2024-06-21  07:22AM   \n",
+              "3   AMZN  2024-06-21  07:00AM   \n",
+              "4   AMZN  2024-06-21  06:52AM   \n",
+              "\n",
+              "                                               title  \n",
+              "0  Inside Amazons race to become a $10 trillion g...  \n",
+              "1  Amazon will stop using those little plastic pi...  \n",
+              "2               3 Penny Stocks to Buy Now: June 2024  \n",
+              "3  Microsoft's AI Edge: Why MSFT Stock Is Poised ...  \n",
+              "4  Hype-nosis: Snap Out of the Trance and See The...  "
+            ]
+          },
+          "execution_count": 6,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "# Checkout the first five rows of the dataframe\n",
+        "df.head()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "2CauTpgZBg4B"
+      },
+      "source": [
+        "**Groq:**\n",
+        "\n",
+        "Groq is a company that provides a hardware platform for efficient AI inference.\n",
+        "\n",
+        "They’ve developed the world’s first Language Processing Unit™, or LPU. The Groq\n",
+        "\n",
+        "LPU is designed to accelerate AI workloads, including inference for large\n",
+        "\n",
+        "language models."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "DEtzXZJ_Czyd"
+      },
+      "source": [
+        "Here I used the groq api to analyse the sentiments of stock news article"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 22,
+      "metadata": {
+        "id": "FbKuMp924AOB"
+      },
+      "outputs": [],
+      "source": [
+        "from groq import Groq\n",
+        "\n",
+        "# Enter your api key\n",
+        "client = Groq(api_key=\"Enter_your_api_here\")\n",
+        "\n",
+        "# Function to perform sentiment analysis using Groq API\n",
+        "def sentiment_analysis(text):\n",
+        "    chat_completion = client.chat.completions.create(\n",
+        "        messages= [ {\"role\": \"system\", \"content\": \"\"\"You are trained to analyze and detect the sentiment of given text.\n",
+        "                                                          If you're unsure of an answer, you can say \"not sure\" and recommend users to review manually.\"\"\"},\n",
+        "                    {\"role\": \"user\", \"content\": f\"\"\"Identify the sentiment towards the stocks from the news article , where the sentiment score should be from -10 to +10 where -10 being the most negative and +10 being the most positve , and 0 being neutral.\n",
+        "                              Article : {text}\"\"\"}],\n",
+        "        model=\"llama3-8b-8192\", # specify model used to analyse the sentments\n",
+        "        temperature=0.5,\n",
+        "        max_tokens=1024,\n",
+        "        stop=None,\n",
+        "        stream=False,\n",
+        "    )\n",
+        "\n",
+        "    response_text = chat_completion.choices[0].message.content.strip().lower()\n",
+        "    return response_text"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Emq4mJOmBiyX"
+      },
+      "source": [
+        "The sentiment score is divided as:\n",
+        "\n",
+        "-10 for most negative\n",
+        "\n",
+        "+10 for most positive\n",
+        "\n",
+        "0 for neutral"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "vMWqaf6tBIAW"
+      },
+      "source": [
+        "Analysing the sentiments of different news articles with explanation:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 23,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "FHG4uwFQcXEn",
+        "outputId": "b5d30323-4823-499d-9ba3-897f37f6431e"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "after analyzing the article, i would rate the sentiment towards the stocks as +6.\n",
+            "\n",
+            "the article appears to be positive towards the companies mentioned, particularly mag 7, which is described as laying down \"ai 'bedrock'\", implying a strong foundation for their ai technology. the phrase \"as nvidia, apple show cracks\" is likely referring to the challenges faced by those companies, but it's not the main focus of the article, which is on mag 7's achievement.\n",
+            "\n",
+            "overall, the tone is optimistic and highlights mag 7's success, which suggests a positive sentiment towards the company.\n"
+          ]
+        }
+      ],
+      "source": [
+        "print(sentiment_analysis(df['title'][13]))"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 43,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "ir494eKvAoC3",
+        "outputId": "05029a5a-84f2-4528-b735-833a2a7b4afc"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "after analyzing the article, i would say that the sentiment towards the stocks is:\n",
+            "\n",
+            "sentiment score: +8\n",
+            "\n",
+            "reasoning:\n",
+            "\n",
+            "the article is discussing how amazon is disrupting the streaming advertising market, which is a positive development for amazon's stock. the tone of the article is informative and neutral, but the overall implication is that amazon's entry into the market is a significant event that could have a positive impact on its stock price. there is no mention of negative aspects or concerns about amazon's stock, which suggests a positive sentiment.\n"
+          ]
+        }
+      ],
+      "source": [
+        "print(sentiment_analysis(df['title'][20]))"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 45,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "Y-EUE8R9AuF0",
+        "outputId": "805e47cc-eca2-435a-8601-c099a15242ca"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "the sentiment towards the stocks in this news article is likely to be negative. the article is reporting on a fine imposed on amazon by the state of california, which implies that amazon is being penalized for violating labor laws. this could potentially have a negative impact on the company's stock price.\n",
+            "\n",
+            "sentiment score: -5\n",
+            "\n",
+            "note: the sentiment score is not extremely negative (-10), as the fine is a specific issue and may not have a significant impact on the company's overall performance. however, it is still negative due to the implication that amazon is being penalized for violating labor laws.\n"
+          ]
+        }
+      ],
+      "source": [
+        "print(sentiment_analysis(df['title'][75]))"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 48,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "KwpNVcCwA2Da",
+        "outputId": "f1be8f2e-df50-4133-e663-d9f016c30f7c"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "after analyzing the article, i would rate the sentiment towards the stocks as 8 out of 10, leaning towards being positive.\n",
+            "\n",
+            "the article is discussing the potential for reddit to continue growing, which suggests a positive outlook for the company's stock performance. the use of phrases such as \"more room to grow\" and \"analyst\" implies a sense of optimism and confidence in reddit's future prospects.\n",
+            "\n",
+            "here's a breakdown of the sentiment:\n",
+            "\n",
+            "* positive words/phrases: \"more room to grow\", \"analyst\"\n",
+            "* neutral words/phrases: none\n",
+            "* negative words/phrases: none\n",
+            "\n",
+            "overall, the sentiment is strongly positive, indicating a high likelihood of the stock performing well in the future.\n"
+          ]
+        }
+      ],
+      "source": [
+        "print(sentiment_analysis(df['title'][30]))"
+      ]
+    }
+  ],
+  "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "gpuType": "T4",
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}


### PR DESCRIPTION
## 🛠️ Related Issue
- Closes #380 

## 📝 Description
<!-- Please include a brief description of the changes or features added -->

Using Groq API, I performed sentiment analysis on stock news article data of Amazon, Google, and Meta that is fetched from the FinViz website.

In web scraping I used 'urllib' to send HTTP requests and ' BeautifulSoup ' to parse HTML content. 

The parsed news articles are organized into pandas dataframe with columns for ticker symbol, date, time, and title.

To analyse the sentiments with reasoning, I initializes the Groq client, sends requests to the API using predefined messages, and processes the responses to extract sentiment analysis results.

## 🔍 Type of PR

- [ ] 🐛 Bug fix
- [x] ✨ Feature enhancement
- [ ] 📚 Documentation update
- [ ] 🛑 Other (specify): _______________

## ✅ Checklist
<!-- Put an "X" inside [] to check the box -->
- [X] I have performed a self-review of my code.
- [X] I have read and followed the Contribution Guidelines.
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [X] I have commented my code, particularly in hard-to-understand areas.

## ℹ️ Additional Context
<!-- Include any additional information or context that might be helpful for reviewers -->
This code will analyse the sentiments of stocks of amazon, google and meta, with the help of news articles data that is fetched from FinViz stock market website. It will give a particular score to the sentiments between -10 (more negative) to +10 ( more positive) and 0 for neutral  with proper reasoning.
